### PR TITLE
Fix for non-library tracks not being displayed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <repository>
             <id>jcenter</id>
             <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     <dependencies>

--- a/src/main/resources/scripts/macos15/itunes_track_info_script.applescript
+++ b/src/main/resources/scripts/macos15/itunes_track_info_script.applescript
@@ -8,51 +8,51 @@ property savedTrack : missing value
 property savedPlayerState : missing value
 
 repeat
-	delay 1
-	# If iTunes is not running, set the state to "STOPPED" and do nothing
-	if application "Music" is not running then
-		if state is not STR_STOPPED then
-			set state to STR_STOPPED
-			log state
-		end if
-	else
-		# If iTunes is running, execute the logic inside a try block so that, if iTunes is closed during the execution, the script doesn't launch an exception
-		try
-			tell application "Music"
-				set currentPlayerState to player state
-				
-				if currentPlayerState is not playing and currentPlayerState is not paused then
-					# If there's no song playing or paused, set the state to "STOPPED" and do nothing
-					if state is not STR_STOPPED then
-						set state to STR_STOPPED
-						log state
-					end if
-				else
-					set currentTrack to current track
-					
-					# If the current song or the player status has changed, log the new track information
-					if currentPlayerState is not savedPlayerState or currentTrack is not savedTrack then
-						if currentPlayerState is playing then
-							set state to STR_PLAYING
-						else
-							set state to STR_PAUSED
-						end if
-						
-						# Write the track main information in the log
-						log name of current track & ";;" & artist of current track & ";;" & album of current track & ";;" & state & ";;" & player position & ";;" & duration of current track & ";;" & track number of current track & ";;" & track count of current track
-					end if
-					
-					# Update the player state and song name to detect when the track changes
-					set savedPlayerState to currentPlayerState
-					set savedTrack to currentTrack
-				end if
-			end tell
-		on error
-			# If iTunes is closed, set the state to "STOPPED" and do nothing
-			if state is not STR_STOPPED then
-				set state to STR_STOPPED
-				log state
-			end if
-		end try
-	end if
+    delay 1
+    # If iTunes is not running, set the state to "STOPPED" and do nothing
+    if application "Music" is not running then
+        if state is not STR_STOPPED then
+            set state to STR_STOPPED
+            log state
+        end if
+    else
+        # If iTunes is running, execute the logic inside a try block so that, if iTunes is closed during the execution, the script doesn't launch an exception
+        try
+            tell application "Music"
+                set currentPlayerState to player state
+                
+                if currentPlayerState is not playing and currentPlayerState is not paused then
+                    # If there's no song playing or paused, set the state to "STOPPED" and do nothing
+                    if state is not STR_STOPPED then
+                        set state to STR_STOPPED
+                        log state
+                    end if
+                else
+                    set currentTrack to current track
+                    
+                    # If the current song or the player status has changed, log the new track information
+                    if currentPlayerState is not savedPlayerState or currentTrack is not savedTrack then
+                        if currentPlayerState is playing then
+                            set state to STR_PLAYING
+                        else
+                            set state to STR_PAUSED
+                        end if
+                        
+                        # Write the track main information in the log
+                        log name of current track & ";;" & artist of current track & ";;" & album of current track & ";;" & state & ";;" & player position & ";;" & duration of current track & ";;" & track number of current track & ";;" & track count of current track
+                    end if
+                    
+                    # Update the player state and song name to detect when the track changes
+                    set savedPlayerState to currentPlayerState
+                    set savedTrack to currentTrack
+                end if
+            end tell
+        on error
+            # If iTunes is closed, set the state to "STOPPED" and do nothing
+            if state is not STR_STOPPED then
+                set state to STR_STOPPED
+                log state
+            end if
+        end try
+    end if
 end repeat

--- a/src/main/resources/scripts/macos15/itunes_track_info_script.applescript
+++ b/src/main/resources/scripts/macos15/itunes_track_info_script.applescript
@@ -8,51 +8,51 @@ property savedTrack : missing value
 property savedPlayerState : missing value
 
 repeat
-    delay 1
-    # If iTunes is not running, set the state to "STOPPED" and do nothing
-    if application "Music" is not running then
-        if state is not STR_STOPPED then
-            set state to STR_STOPPED
-            log state
-        end if
-    else
-        # If iTunes is running, execute the logic inside a try block so that, if iTunes is closed during the execution, the script doesn't launch an exception
-        try
-            tell application "Music"
-                set currentPlayerState to player state
-                
-                if currentPlayerState is not playing and currentPlayerState is not paused then
-                    # If there's no song playing or paused, set the state to "STOPPED" and do nothing
-                    if state is not STR_STOPPED then
-                        set state to STR_STOPPED
-                        log state
-                    end if
-                else
-                    set currentTrack to current track
-                    
-                    # If the current song or the player status has changed, log the new track information
-                    if currentPlayerState is not savedPlayerState or currentTrack is not savedTrack then
-                        if currentPlayerState is playing then
-                            set state to STR_PLAYING
-                        else
-                            set state to STR_PAUSED
-                        end if
-                        
-                        # Write the track main information in the log
-                        log name of currentTrack & ";;" & artist of currentTrack & ";;" & album of currentTrack & ";;" & state & ";;" & player position & ";;" & duration of currentTrack & ";;" & track number of currentTrack & ";;" & track count of currentTrack
-                    end if
-                    
-                    # Update the player state and song name to detect when the track changes
-                    set savedPlayerState to currentPlayerState
-                    set savedTrack to currentTrack
-                end if
-            end tell
-        on error
-            # If iTunes is closed, set the state to "STOPPED" and do nothing
-            if state is not STR_STOPPED then
-                set state to STR_STOPPED
-                log state
-            end if
-        end try
-    end if
+	delay 1
+	# If iTunes is not running, set the state to "STOPPED" and do nothing
+	if application "Music" is not running then
+		if state is not STR_STOPPED then
+			set state to STR_STOPPED
+			log state
+		end if
+	else
+		# If iTunes is running, execute the logic inside a try block so that, if iTunes is closed during the execution, the script doesn't launch an exception
+		try
+			tell application "Music"
+				set currentPlayerState to player state
+				
+				if currentPlayerState is not playing and currentPlayerState is not paused then
+					# If there's no song playing or paused, set the state to "STOPPED" and do nothing
+					if state is not STR_STOPPED then
+						set state to STR_STOPPED
+						log state
+					end if
+				else
+					set currentTrack to current track
+					
+					# If the current song or the player status has changed, log the new track information
+					if currentPlayerState is not savedPlayerState or currentTrack is not savedTrack then
+						if currentPlayerState is playing then
+							set state to STR_PLAYING
+						else
+							set state to STR_PAUSED
+						end if
+						
+						# Write the track main information in the log
+						log name of current track & ";;" & artist of current track & ";;" & album of current track & ";;" & state & ";;" & player position & ";;" & duration of current track & ";;" & track number of current track & ";;" & track count of current track
+					end if
+					
+					# Update the player state and song name to detect when the track changes
+					set savedPlayerState to currentPlayerState
+					set savedTrack to currentTrack
+				end if
+			end tell
+		on error
+			# If iTunes is closed, set the state to "STOPPED" and do nothing
+			if state is not STR_STOPPED then
+				set state to STR_STOPPED
+				log state
+			end if
+		end try
+	end if
 end repeat


### PR DESCRIPTION
Hi, the macos15 applescript was not working for tracks which are not in the library (#16). This _should_ fix it (I've only tested it by running the applescript, I did not build the app around it) :)